### PR TITLE
Add bookshelf-delivery-example to projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The goal is to help every hanami developer to build an awesome product/service.
 * [link-shortener](https://github.com/davydovanton/link-shortener) - Simple hanami link shortener application.
 * [firefly](https://github.com/ariejan/firefly) - Firefly is an elegant solution for personal media hosting and URL shortening.
 * [repressed_museum](https://github.com/vasspilka/repressed_museum) - A simple mostly static website, features basic i18n and docker integration
+* [bookshelf-delivery-example](https://github.com/bruz/bookshelf-delivery-example) - An example app with a web GUI, API and CLI using shared interactors.
 
 ## Useful Links
 * [StackOverflow questions](http://stackoverflow.com/questions/tagged/hanami)


### PR DESCRIPTION
This is a just a simple app I built just to get familiar with Hanami and experiment with the idea of taking an app's use cases and providing multiple interfaces around them. Given how few open source Hanami projects I was able to find as examples when figuring out how to build this, I thought it could be of use to others.
