### PR TITLE
Add information about Hanami Mastery initiative

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ http://github.com/makedecision-org/core
 
 ## Useful Links
 * [Community page on the official site](http://hanamirb.org/community/)
+* [Hanami Mastery](https://hanamimastery.com) - Articles and Video tutorials, featuring Hanami, its dependencies (ROM-RB, DRY-RB) and all great ruby projects that may be integrated with Hanami.
 
 ### Blog Posts
 * [What I learned building an app in Hanami](https://rossta.net/blog/what-i-learned-about-hanami.html)


### PR DESCRIPTION
Hanami Mastery is a project focused on Hanami and its dependencies, which the community can benefit from a lot.

It's actively managed, new episodes are released every 1-2 weeks.