### PR TITLE
Add jay_doubleu_tee JWT authorization gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The goal is to help every hanami developer to build an awesome product/service.
 * [hanami-id](https://github.com/leemour/hanami_id) - Large authentication library, with generators
 
 ### Authorization
+* [jay_doubleu_tee](https://github.com/hanamimastery/jay_doublu_tee) - JWT authorization wrapper for all Ruby apps, including Hanami projects.
 * [kan](https://github.com/davydovanton/kan) - Simple, light and functional authorization library
 * [tachiban](https://github.com/sebastjan-hribar/tachiban) - Tachiban includes policy based authorization support
 


### PR DESCRIPTION
### Overview

Adding the `jay_doubleu_tee` gem, which is a small wrapper over JWT for easy integration with any rack-based applications.

Video guide: https://hanamimastery.com/episodes/12-authorization-with-jwt